### PR TITLE
[xs] add gfm extension - refs #21

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,5 @@ pages:
   - Upload: publishers/upload.md
   - Use: publishers/use.md
 theme: readthedocs
+markdown_extensions:
+  - pymdownx.github


### PR DESCRIPTION
We wanted to add `GFM` to the docs.

There were 2 main extension for this 
- https://github.com/Zopieux/py-gfm
- http://facelessuser.github.io/pymdown-extensions/extensions/github

The second is lot more maintained and had some extra features. That is why choosing the 2nd one. 